### PR TITLE
fix(navigation): correct icons and add empty screens for smoother navigation

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -142,6 +142,7 @@ dependencies {
     implementation(libs.androidx.material3)
     implementation(libs.androidx.navigation.compose)
     implementation(platform(libs.androidx.compose.bom))
+    implementation(libs.androidx.ui.test.android)
     testImplementation(libs.test.core.ktx)
     debugImplementation(libs.androidx.ui.tooling)
     debugImplementation(libs.androidx.ui.test.manifest)

--- a/app/src/main/java/com/github/se/orator/MainActivity.kt
+++ b/app/src/main/java/com/github/se/orator/MainActivity.kt
@@ -23,6 +23,8 @@ import com.github.se.orator.ui.navigation.Screen
 import com.github.se.orator.ui.profile.CreateAccountScreen
 import com.github.se.orator.ui.profile.EditProfileScreen
 import com.github.se.orator.ui.profile.ProfileScreen
+import com.github.se.orator.ui.screens.ViewConnectScreen
+import com.github.se.orator.ui.screens.ViewFunScreen
 import com.github.se.orator.ui.settings.SettingsScreen
 import com.github.se.orator.ui.theme.ProjectTheme
 import com.github.se.orator.ui.theme.mainScreen.MainScreen
@@ -88,6 +90,14 @@ fun OratorApp() {
           route = Route.FRIENDS,
       ) {
         composable(Screen.FRIENDS) { ViewFriendsScreen(navigationActions, userProfileViewModel) }
+      }
+
+      //// temporarily adding those empty screens before we implement their functionalities
+      composable(Screen.FUN_SCREEN) {
+        ViewFunScreen(navigationActions, userProfileViewModel) // Your composable function for Fun Screen
+      }
+      composable(Screen.CONNECT_SCREEN) {
+        ViewConnectScreen(navigationActions, userProfileViewModel) // Your composable function for Connect Screen
       }
 
       navigation(

--- a/app/src/main/java/com/github/se/orator/ui/mainScreen/MainScreen.kt
+++ b/app/src/main/java/com/github/se/orator/ui/mainScreen/MainScreen.kt
@@ -43,6 +43,7 @@ import com.github.se.orator.R
 import com.github.se.orator.ui.navigation.BottomNavigationMenu
 import com.github.se.orator.ui.navigation.LIST_TOP_LEVEL_DESTINATION
 import com.github.se.orator.ui.navigation.NavigationActions
+import com.github.se.orator.ui.navigation.Screen
 import kotlinx.coroutines.delay
 
 /**
@@ -67,7 +68,7 @@ fun MainScreen(navigationActions: NavigationActions) {
               fontSize = 47.sp,
               fontWeight = FontWeight.Bold)
 
-          ButtonRow()
+            ButtonRow(navigationActions)
 
           // Practice mode cards
           AnimatedCards()
@@ -85,34 +86,44 @@ fun MainScreen(navigationActions: NavigationActions) {
  * The implementation of the toolbar containing the different selection buttons of the main screen
  */
 @Composable
-fun ButtonRow() {
-  Row(
-      modifier = Modifier.testTag("toolbar").fillMaxWidth().padding(top = 16.dp),
-      horizontalArrangement = Arrangement.spacedBy(40.dp, Alignment.CenterHorizontally),
-  ) {
-    // Popular Button
-    SectionButton("Popular")
+fun ButtonRow(navigationActions: NavigationActions) {
+    Row(
+        modifier = Modifier.testTag("toolbar").fillMaxWidth().padding(top = 16.dp),
+        horizontalArrangement = Arrangement.spacedBy(40.dp, Alignment.CenterHorizontally),
+    ) {
+        SectionButton("Popular") {
+            // Do nothing, stays on the same screen
+        }
 
-    // Fun Button
-    SectionButton("Fun")
+        // Fun Button
+        SectionButton("Fun") {
+            navigationActions.navigateTo(Screen.FUN_SCREEN)
+        }
 
-    // Connect Button
-    SectionButton("Connect")
-  }
+        // Connect Button
+        SectionButton("Connect") {
+            navigationActions.navigateTo(Screen.CONNECT_SCREEN)
+        }
+    }
 }
+
 
 /**
  * @param text the text displayed in each button describing the different selections
  *
  * The implementation of a button
  */
+
 @Composable
-fun SectionButton(text: String) {
-  TextButton(
-      onClick = { /* TODO: Add your onClick action */}, modifier = Modifier.testTag("button")) {
+fun SectionButton(text: String, onClick: () -> Unit) {
+    TextButton(
+        onClick = onClick,
+        modifier = Modifier.testTag("button")
+    ) {
         Text(text = text, color = Color.Black, fontSize = 20.sp)
-      }
+    }
 }
+
 
 /** Function to create the sliding animation to browse between modes */
 @Composable

--- a/app/src/main/java/com/github/se/orator/ui/navigation/NavigationActions.kt
+++ b/app/src/main/java/com/github/se/orator/ui/navigation/NavigationActions.kt
@@ -2,7 +2,9 @@ package com.github.se.orator.ui.navigation
 
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Menu
+import androidx.compose.material.icons.outlined.Person
 import androidx.compose.material.icons.outlined.Place
+import androidx.compose.material.icons.outlined.Star
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavHostController
@@ -25,6 +27,9 @@ object Screen {
   const val EDIT_PROFILE = "EditProfile Screen"
   const val CREATE_PROFILE = "CreateProfile Screen"
   const val SETTINGS = "Settings Screen"
+  const val FUN_SCREEN = "ViewFunScreen"
+  const val PRACTICE_SCREEN= "ViewPracticeScreen"
+  const val CONNECT_SCREEN = "ViewConnectScreen"
 }
 
 data class TopLevelDestination(val route: String, val icon: ImageVector, val textId: String)
@@ -32,9 +37,9 @@ data class TopLevelDestination(val route: String, val icon: ImageVector, val tex
 object TopLevelDestinations {
   val HOME = TopLevelDestination(route = Route.HOME, icon = Icons.Outlined.Menu, textId = "Home")
   val FRIENDS =
-      TopLevelDestination(route = Route.FRIENDS, icon = Icons.Outlined.Place, textId = "Friends")
+      TopLevelDestination(route = Route.FRIENDS, icon = Icons.Outlined.Star, textId = "Friends")
   val PROFILE =
-      TopLevelDestination(route = Route.PROFILE, icon = Icons.Outlined.Place, textId = "Profile")
+      TopLevelDestination(route = Route.PROFILE, icon = Icons.Outlined.Person, textId = "Profile")
 }
 
 val LIST_TOP_LEVEL_DESTINATION =

--- a/app/src/main/java/com/github/se/orator/ui/screens/Connect.kt
+++ b/app/src/main/java/com/github/se/orator/ui/screens/Connect.kt
@@ -1,0 +1,27 @@
+package com.github.se.orator.ui.screens
+
+import android.annotation.SuppressLint
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import com.github.se.orator.model.profile.UserProfileViewModel
+import com.github.se.orator.ui.navigation.BottomNavigationMenu
+import com.github.se.orator.ui.navigation.LIST_TOP_LEVEL_DESTINATION
+import com.github.se.orator.ui.navigation.NavigationActions
+
+@SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
+@Composable
+fun ViewConnectScreen(
+    navigationActions: NavigationActions,
+    userProfileViewModel: UserProfileViewModel
+){
+    Scaffold(
+        bottomBar = {
+            BottomNavigationMenu(
+                onTabSelect = { route -> navigationActions.navigateTo(route) },
+                tabList = LIST_TOP_LEVEL_DESTINATION,
+                selectedItem = navigationActions.currentRoute())
+        }) {
+        Text("Fun Connect Screen")
+    }
+}

--- a/app/src/main/java/com/github/se/orator/ui/screens/FunScreen.kt
+++ b/app/src/main/java/com/github/se/orator/ui/screens/FunScreen.kt
@@ -1,0 +1,27 @@
+package com.github.se.orator.ui.screens
+
+import android.annotation.SuppressLint
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import com.github.se.orator.model.profile.UserProfileViewModel
+import com.github.se.orator.ui.navigation.BottomNavigationMenu
+import com.github.se.orator.ui.navigation.LIST_TOP_LEVEL_DESTINATION
+import com.github.se.orator.ui.navigation.NavigationActions
+
+@SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
+@Composable
+fun ViewFunScreen(
+    navigationActions: NavigationActions,
+    userProfileViewModel: UserProfileViewModel
+) {
+    Scaffold(
+        bottomBar = {
+            BottomNavigationMenu(
+                onTabSelect = { route -> navigationActions.navigateTo(route) },
+                tabList = LIST_TOP_LEVEL_DESTINATION,
+                selectedItem = navigationActions.currentRoute())
+        }) {
+        Text("Fun Mode Screen")
+    }
+}

--- a/app/src/main/java/com/github/se/orator/ui/screens/PracticeMode.kt
+++ b/app/src/main/java/com/github/se/orator/ui/screens/PracticeMode.kt
@@ -1,0 +1,27 @@
+package com.github.se.orator.ui.screens
+
+import android.annotation.SuppressLint
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import com.github.se.orator.model.profile.UserProfileViewModel
+import com.github.se.orator.ui.navigation.BottomNavigationMenu
+import com.github.se.orator.ui.navigation.LIST_TOP_LEVEL_DESTINATION
+import com.github.se.orator.ui.navigation.NavigationActions
+
+@SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
+@Composable
+fun ViewPracticeScreen(
+    navigationActions: NavigationActions,
+    userProfileViewModel: UserProfileViewModel
+) {
+    Scaffold(
+        bottomBar = {
+            BottomNavigationMenu(
+                onTabSelect = { route -> navigationActions.navigateTo(route) },
+                tabList = LIST_TOP_LEVEL_DESTINATION,
+                selectedItem = navigationActions.currentRoute())
+        }) {
+        Text("Practice Mode x")
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -67,6 +67,7 @@ androidxCoreKtx = "1.6.1"
 
 # Coil
 coil = "2.0.0"
+uiTestAndroid = "1.7.3"
 
 [libraries]
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "activityCompose" }
@@ -123,6 +124,7 @@ firebase-storage = { module = "com.google.firebase:firebase-storage-ktx", versio
 firebase-appcheck = { module = "com.google.firebase:firebase-appcheck", version = "16.1.2" }
 firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "firebase-bom" }
 coil-compose = { module = "io.coil-kt:coil-compose", version.ref = "coil" }
+androidx-ui-test-android = { group = "androidx.compose.ui", name = "ui-test-android", version.ref = "uiTestAndroid" }
 
 
 [plugins]


### PR DESCRIPTION
This PR includes two primary changes:

- Navigation Bar Icon Correction: Replaced incorrect icons in the bottom navigation bar to ensure they match the design and expectations. Related to issue #19 
- Added Empty Screens for Fun and Connect Modes: Created placeholder (empty) screens for the Fun and Connect modes to provide smoother and safer navigation during the app's flow.  #22 

Files Affected:

-  NavigationActions.kt : Added the Screen val and changed the icons of the bottom navigation bar 
-  MainScreen.kt : Fixed the ButtonSection by implementing the navigation action 
-  Created the folder screens with the Placeholders
  
Testing:
  I only tested it manually for now. Opened a new issue for the testing of the MainScreen #23

Future Considerations:
    Placeholder screens will be fleshed out with actual content in future development cycles.

Let me know if you need any further adjustments!